### PR TITLE
fix small typo in handler example

### DIFF
--- a/content/en/book/guid/hello_world.md
+++ b/content/en/book/guid/hello_world.md
@@ -59,7 +59,7 @@ There are many ways to write function handler.
     }
     ```
 
-- You can omit function arguments if they do not used, like ```_req```, ```_depot```, ```_ctrl``` in this example:
+- You can omit function arguments if they are not used, like ```_req```, ```_depot```, ```_ctrl``` in this example:
 
     ``` rust
     #[handler]


### PR DESCRIPTION
This PR fixes a small typo in tutorial/simple example.