### PR TITLE
Update proxy.md

### DIFF
--- a/zh-hans/book/middlewares/proxy.md
+++ b/zh-hans/book/middlewares/proxy.md
@@ -12,7 +12,7 @@ salvo = { version = "*", features = ["proxy"] }
 
 ```rust
 use salvo::prelude::*;
-use salvo_extra::proxy::ProxyHandler;
+use salvo::proxy::Proxy;
 
 #[tokio::main]
 async fn main() {
@@ -22,12 +22,12 @@ async fn main() {
         .push(
             Router::new()
                 .path("google/<**rest>")
-                .handle(ProxyHandler::new(vec!["https://www.google.com".into()])),
+                .handle(Proxy::<Vec<&str>>::new(vec!["https://www.google.com"])),
         )
         .push(
             Router::new()
                 .path("baidu/<**rest>")
-                .handle(ProxyHandler::new(vec!["https://www.baidu.com".into()])),
+                .handle(Proxy::<Vec<&str>>::new(vec!["https://www.baidu.com"])),
         );
     Server::new(TcpListener::bind("127.0.0.1:7878")).serve(router).await;
 }


### PR DESCRIPTION
一些API已经更新，示例代码也需要更改
（使用salvo::proxy::Proxy而不是salvo_extra::proxy::ProxyHandler） （需要添加类型标注）