### PR TITLE
fix: typo of code example in `cors` 

### DIFF
--- a/book/middlewares/cors.md
+++ b/book/middlewares/cors.md
@@ -14,7 +14,7 @@ salvo = { version = "*", features = ["cors"] }
 
 ```rust
 use salvo::prelude::*;
-use salvo_extra::cors::Cors;
+use salvo::cors::Cors;
 
 #[handler]
 async fn hello() -> &'static str {
@@ -26,8 +26,8 @@ async fn main() {
     tracing_subscriber::fmt().init();
 
     let cors_handler = Cors::builder()
-        .with_allow_origin("https://salvo.rs")
-        .with_allow_methods(vec!["GET", "POST", "DELETE"])
+        .allow_origin("https://salvo.rs")
+        .allow_methods(vec!["GET", "POST", "DELETE"])
         .build();
 
     let router = Router::with_hoop(cors_handler).get(hello).options(empty_handler);

--- a/zh-hans/book/middlewares/cors.md
+++ b/zh-hans/book/middlewares/cors.md
@@ -14,7 +14,7 @@ salvo = { version = "*", features = ["cors"] }
 
 ```rust
 use salvo::prelude::*;
-use salvo_extra::cors::Cors;
+use salvo::cors::Cors;
 
 #[handler]
 async fn hello() -> &'static str {
@@ -26,8 +26,8 @@ async fn main() {
     tracing_subscriber::fmt().init();
 
     let cors_handler = Cors::builder()
-        .with_allow_origin("https://salvo.rs")
-        .with_allow_methods(vec!["GET", "POST", "DELETE"])
+        .allow_origin("https://salvo.rs")
+        .allow_methods(vec!["GET", "POST", "DELETE"])
         .build();
 
     let router = Router::with_hoop(cors_handler).get(hello).options(empty_handler);

--- a/zh-hant/book/middlewares/cors.md
+++ b/zh-hant/book/middlewares/cors.md
@@ -14,7 +14,7 @@ salvo = { version = "*", features = ["cors"] }
 
 ```rust
 use salvo::prelude::*;
-use salvo_extra::cors::Cors;
+use salvo::cors::Cors;
 
 #[handler]
 async fn hello() -> &'static str {
@@ -26,8 +26,8 @@ async fn main() {
     tracing_subscriber::fmt().init();
 
     let cors_handler = Cors::builder()
-        .with_allow_origin("https://salvo.rs")
-        .with_allow_methods(vec!["GET", "POST", "DELETE"])
+        .allow_origin("https://salvo.rs")
+        .allow_methods(vec!["GET", "POST", "DELETE"])
         .build();
 
     let router = Router::with_hoop(cors_handler).get(hello).options(empty_handler);


### PR DESCRIPTION
the import sentence of `cors` and method call of `cors` are incorrect under salvo version 0.37