### PR TITLE
Update  translation of the cors about cors.md

### DIFF
--- a/src/zh-hans/book/middlewares/cors.md
+++ b/src/zh-hans/book/middlewares/cors.md
@@ -1,6 +1,6 @@
 # CORS
 
-CORS 中间件可以用于 [跨域资源共享](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/CORS).
+CORS 中间件可以用于 [跨源资源共享](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/CORS).
 
 由于浏览器会发 `Method::OPTIONS` 的请求, 所以需要增加对此类请求的处理. 可以对根 `Router` 添加 `empty_handler` 一劳永逸地处理这种情况.
 


### PR DESCRIPTION
这里应该译为「源」，简中的译法一直是错的，不过 MDN 已经改过来了，参考：<https://github.com/mdn/translated-content/pull/3096#issuecomment-1041021553>