### PR TITLE
Update version of salvo in Quick Start

### DIFF
--- a/src/book/guide.md
+++ b/src/book/guide.md
@@ -24,7 +24,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-salvo = "0.49"
+salvo = "0.55"
 tokio = { version = "1", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"


### PR DESCRIPTION
Get a versions are yanked error for suggested version:

```
error: failed to select a version for the requirement `salvo = "^0.49"`
candidate versions found which didn't match: 0.55.3, 0.55.2, 0.54.3, ...
```