### PR TITLE
doc-optm: remove useless comma

### DIFF
--- a/src/book/core/router.md
+++ b/src/book/core/router.md
@@ -4,7 +4,7 @@
 
 Router can route http requests to different handlers. This is a basic and key feature in salvo.
 
-The interior of `Router` is actually composed of a series of filters (Filter). When a request comes, the route will test itself and its descendants in order to see if they can match the request in the order they were added. , then execute the middleware on the entire chain formed by the route and its descendants in sequence. If the status of `Response` is set to error (4XX, 5XX) or jump (3XX) during processing, the subsequent middleware and `Handler` will be skipped. You can also manually adjust `ctrl.skip_rest()` to skip subsequent middleware and `Handler`.
+The interior of `Router` is actually composed of a series of filters (Filter). When a request comes, the route will test itself and its descendants in order to see if they can match the request in the order they were added, and then execute the middleware on the entire chain formed by the route and its descendants in sequence. If the status of `Response` is set to error (4XX, 5XX) or jump (3XX) during processing, the subsequent middleware and `Handler` will be skipped. You can also manually adjust `ctrl.skip_rest()` to skip subsequent middleware and `Handler`.
 
 ## Write in flat way
 We can write routers in flat way, like this:


### PR DESCRIPTION
Placing a comma immediately after a period disrupts the flow of the sentence.