### PR TITLE
fix custom-error-page bug

### DIFF
--- a/codes/custom-error-page/src/main.rs
+++ b/codes/custom-error-page/src/main.rs
@@ -27,7 +27,7 @@ fn create_service() -> Service {
 
 #[handler]
 async fn handle404(res: &mut Response, ctrl: &mut FlowCtrl) {
-    if let Some(StatusCode::NOT_FOUND) = res.status_code {
+    if StatusCode::NOT_FOUND == res.status_code.unwrap_or(StatusCode::NOT_FOUND) {
         res.render("Custom 404 Error Page");
         ctrl.skip_rest();
     }


### PR DESCRIPTION
the framework does not set status codes by default