### PR TITLE
fix english and spanish docs page about opentelemetry

### DIFF
--- a/docs/book/features/open-telemetry.md
+++ b/docs/book/features/open-telemetry.md
@@ -1,3 +1,3 @@
 # OpenTelemetry
 
-Proporciona middleware compatible con OpenTelemetry. Puedes consultar el [ejemplo](https://github.com/salvo-rs/salvo/tree/main/examples/otel-jaeger) en la biblioteca oficial.
+Provides middleware that supports OpenTelemetry. You can refer to the [example](https://github.com/salvo-rs/salvo/tree/main/examples/otel-jaeger) in the official library.

--- a/docs/es/book/features/open-telemetry.md
+++ b/docs/es/book/features/open-telemetry.md
@@ -1,3 +1,3 @@
 # OpenTelemetry
 
-提供对 OpenTelemetry 支持的中间件. 可以参考官方库中的[示例](https://github.com/salvo-rs/salvo/tree/main/examples/otel-jaeger).
+Proporciona middleware compatible con OpenTelemetry. Puedes consultar el [ejemplo](https://github.com/salvo-rs/salvo/tree/main/examples/otel-jaeger) en la biblioteca oficial.


### PR DESCRIPTION
in commit 27f8576 the english page was replaced by the spanish one and the spanish one with the simplified chinese one. this fixes that. the english page here is what it was before that commit.