### PR TITLE
Fix OpenAPI docs

### DIFF
--- a/docs/de/guide/features/openapi.mdx
+++ b/docs/de/guide/features/openapi.mdx
@@ -1,4 +1,3 @@
-```markdown
 import { Tab, Tabs } from 'rspress/theme';
 import OapiHelloCode from '../../../../codes_md/oapi-hello/src/main.mdx';
 import OapiHelloCargoCode from '../../../../codes_md/oapi-hello/Cargo.mdx';
@@ -230,5 +229,4 @@ pub async fn create_todo(new_todo: JsonBody<Todo>) -> Result<StatusCode, Error> 
 [primitive]: https://doc.rust-lang.org/std/primitive/index.html
 [serde attributes]: https://serde.rs/attributes.html
 [std_string]: https://doc.rust-lang.org/std/string/struct.String.html
-```
 {/* 本行由工具自动生成,原文哈希值:66e3964ffc9d02e6953bdf48a6d2ed87 */}

--- a/docs/en/guide/features/openapi.mdx
+++ b/docs/en/guide/features/openapi.mdx
@@ -1,4 +1,3 @@
-```markdown
 import { Tab, Tabs } from 'rspress/theme';
 import OapiHelloCode from '../../../../codes_md/oapi-hello/src/main.mdx';
 import OapiHelloCargoCode from '../../../../codes_md/oapi-hello/Cargo.mdx';

--- a/docs/fr/guide/features/openapi.mdx
+++ b/docs/fr/guide/features/openapi.mdx
@@ -1,4 +1,3 @@
-```markdown
 import { Tab, Tabs } from 'rspress/theme';
 import OapiHelloCode from '../../../../codes_md/oapi-hello/src/main.mdx';
 import OapiHelloCargoCode from '../../../../codes_md/oapi-hello/Cargo.mdx';
@@ -162,5 +161,4 @@ async fn creer_todo(new_todo: JsonBody<Todo>) -> Result<StatusCode, Erreur> {
 [path_parameters]: openapi.html#parameters-attributes
 [style]: https://docs.rs/salvo-oapi/latest/salvo_oapi/enum.ParameterStyle.html
 [in_enum]: https://docs.rs/salvo-oapi/latest/salvo_oapi/enum.ParameterIn.html
-```
 {/* 本行由工具自动生成,原文哈希值:66e3964ffc9d02e6953bdf48a6d2ed87 */}

--- a/docs/ja/guide/features/openapi.mdx
+++ b/docs/ja/guide/features/openapi.mdx
@@ -1,8 +1,6 @@
-```javascript
 import { Tab, Tabs } from 'rspress/theme';
 import OapiHelloCode from '../../../../codes_md/oapi-hello/src/main.mdx';
 import OapiHelloCargoCode from '../../../../codes_md/oapi-hello/Cargo.mdx';
-```
 
 # OpenAPIドキュメント生成
 

--- a/docs/pt/guide/features/openapi.mdx
+++ b/docs/pt/guide/features/openapi.mdx
@@ -1,4 +1,3 @@
-```portuguese
 import { Tab, Tabs } from 'rspress/theme';
 import OapiHelloCode from '../../../../codes_md/oapi-hello/src/main.mdx';
 import OapiHelloCargoCode from '../../../../codes_md/oapi-hello/Cargo.mdx';

--- a/docs/ru/guide/features/openapi.mdx
+++ b/docs/ru/guide/features/openapi.mdx
@@ -1,4 +1,3 @@
-```markdown
 import { Tab, Tabs } from 'rspress/theme';
 import OapiHelloCode from '../../../../codes_md/oapi-hello/src/main.mdx';
 import OapiHelloCargoCode from '../../../../codes_md/oapi-hello/Cargo.mdx';
@@ -182,5 +181,4 @@ async fn create_todo() -> Result<StatusCode, Error> {
 [to_schema]: https://docs.rs/salvo-oapi/latest/salvo_oapi/trait.ToSchema.html
 [to_parameters]: https://docs.rs/salvo-oapi/latest/salvo_oapi/trait.ToParameters.html
 [path_parameters]: openapi.html#parameters-attributes
-```
 {/* 本行由工具自动生成,原文哈希值:66e3964ffc9d02e6953bdf48a6d2ed87 */}


### PR DESCRIPTION
### **User description**
[These docs](https://salvo.rs/guide/features/openapi.html) are currently displayed incorrectly, with the entire thing embedded in a code block.


___

### **PR Type**
Documentation


___

### **Description**
- Removed unnecessary Markdown code block wrapper from OpenAPI docs

- Fixed formatting issue causing entire page to render as code block


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openapi.mdx</strong><dd><code>Remove erroneous Markdown code block from OpenAPI docs</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/en/guide/features/openapi.mdx

<li>Removed top-level Markdown code block wrapper<br> <li> Ensured proper rendering of documentation content<br> <li> No changes to actual documentation content or examples


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/website/pull/74/files#diff-7caa3bb6db5560d08c61d9d90c374c2370734f0549aee741751c6a0b9997bef3">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>