### PR TITLE
Add Documentation for Allowing All Origins in Salvo CORS Configuration

### DIFF
--- a/docs/en/guide/features/cors.mdx
+++ b/docs/en/guide/features/cors.mdx
@@ -57,6 +57,26 @@ import CorsCargoCode from '../../../../codes_md/cors/Cargo.mdx';
   </Tab>
 </Tabs>
 
+## Allowing All Origins
+
+In some development scenarios, you may want to temporarily allow requests from any origin. Salvo supports this through the `AllowOrigin::any()` option.
+
+Before using it, import the AllowOrigin enum:
+
+```rust
+use salvo::cors::AllowOrigin;
+```
+
+Then configure the CORS middleware like this:
+
+```rust
+ let cors = Cors::new()
+        .allow_origin(AllowOrigin::any())
+        .allow_methods(vec![Method::GET, Method::POST, Method::DELETE])
+        .allow_headers("authorization")
+        .into_handler();
+```
+
 ## Main Configuration Options
 
 The CORS middleware provides various configuration options:


### PR DESCRIPTION
This pull request adds a new section to the CORS documentation that explains how to enable support for all origins using `AllowOrigin::any()`. The update includes:

- A clear explanation of when and why `AllowOrigin::any()` may be used

- Required import instructions (`use salvo::cors::AllowOrigin;`)

- A clean code example showing how to configure CORS to accept requests from any origin

- A caution note about using this configuration in production environments

This enhancement provides clearer guidance for developers who need permissive CORS behavior during development or testing.