### PR TITLE
docs: add AI Skills documentation for salvo-skills

### DIFF
--- a/docs/de/guide/topics/_meta.json
+++ b/docs/de/guide/topics/_meta.json
@@ -6,5 +6,6 @@
     "use-template-engine",
     "graceful-shutdown",
     "testing",
-    "deployment"
+    "deployment",
+    "ai-skills"
 ]

--- a/docs/de/guide/topics/ai-skills.mdx
+++ b/docs/de/guide/topics/ai-skills.mdx
@@ -1,0 +1,113 @@
+# AI Skills
+
+[Salvo Skills](https://github.com/salvo-rs/salvo-skills) ist eine Sammlung von 27 spezialisierten AI-Agent-Skills für das Salvo Web-Framework. Diese Skills folgen dem offenen [Agent Skills](https://agent-skills.github.io/) Standard und helfen AI-Programmierassistenten, Salvo-Code genauer und effizienter zu verstehen und zu generieren.
+
+## Was sind AI Skills?
+
+AI Skills sind strukturierte Wissensmodule, die AI-Programmierassistenten tiefgehendes, framework-spezifisches Fachwissen bereitstellen. Nach der Integration in Ihre Entwicklungsumgebung ermöglichen sie AI-Tools:
+
+- Genauen, idiomatischen Salvo-Code zu generieren
+- Salvos Architektur und Konventionen zu verstehen (z.B. `#[handler]`-Makro, Router, Depot)
+- Kontextbezogene Anleitungen zu Routing, Middleware, Authentifizierung, WebSocket und mehr bereitzustellen
+
+## Verfügbare Skills (27 insgesamt)
+
+| Kategorie | Skills |
+| --- | --- |
+| **Kern-Framework** | `salvo-basic-app`, `salvo-routing`, `salvo-middleware`, `salvo-error-handling` |
+| **Datenverarbeitung** | `salvo-data-extraction`, `salvo-database`, `salvo-file-handling`, `salvo-static-files`, `salvo-caching` |
+| **Sicherheit** | `salvo-auth`, `salvo-session`, `salvo-csrf`, `salvo-cors`, `salvo-rate-limiter`, `salvo-tls-acme` |
+| **Echtzeit** | `salvo-realtime`, `salvo-websocket`, `salvo-sse` |
+| **Leistung & Betrieb** | `salvo-compression`, `salvo-timeout`, `salvo-concurrency-limiter`, `salvo-graceful-shutdown`, `salvo-logging` |
+| **Erweitert** | `salvo-openapi`, `salvo-proxy`, `salvo-flash`, `salvo-testing` |
+
+## Einrichtungsanleitung
+
+### Claude Code
+
+Kopieren Sie die Skills in das `.claude/skills/`-Verzeichnis Ihres Projekts:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .claude/skills/
+```
+
+Claude Code lädt die Skills automatisch, wenn es mit Ihrem Salvo-Projekt arbeitet.
+
+### GitHub Copilot (VS Code)
+
+1. Kopieren Sie die Skills nach `.github/skills/`:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .github/skills/
+```
+
+2. Aktivieren Sie Agent Skills in den VS Code-Einstellungen:
+
+```json
+{
+  "chat.useAgentSkills": true
+}
+```
+
+Die Skills werden automatisch aktiviert, wenn Sie Salvo-Themen mit Copilot besprechen.
+
+### Cursor
+
+Fügen Sie Skills als Dokumentationskontext in Cursor hinzu:
+
+1. Klonen Sie das Repository:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Erstellen oder bearbeiten Sie die `.cursor/rules`-Datei im Projektstammverzeichnis und fügen Sie hinzu:
+
+```
+Read and follow the skill files in .cursor/skills/ directory for Salvo framework guidance.
+```
+
+3. Kopieren Sie die Skill-Dateien:
+
+```bash
+cp -r salvo-skills/skills .cursor/skills/
+```
+
+Cursor referenziert diese Skill-Dateien beim Generieren von Salvo-bezogenem Code.
+
+### Windsurf
+
+Konfigurieren Sie Skills als Wissenskontext in Windsurf:
+
+1. Klonen Sie das Repository:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Erstellen oder bearbeiten Sie die `.windsurfrules`-Datei im Projektstammverzeichnis und fügen Sie hinzu:
+
+```
+Read and follow the skill files in .windsurf/skills/ directory for Salvo framework guidance.
+```
+
+3. Kopieren Sie die Skill-Dateien:
+
+```bash
+cp -r salvo-skills/skills .windsurf/skills/
+```
+
+### Andere AI-Tools
+
+Für jeden AI-Programmierassistenten, der benutzerdefinierte Anweisungen oder Kontextdateien unterstützt:
+
+1. Repository klonen: `git clone https://github.com/salvo-rs/salvo-skills.git`
+2. Den `skills/`-Ordner in Ihr Projektverzeichnis legen
+3. Ihr AI-Tool so konfigurieren, dass es diese Dateien als Kontext referenziert
+
+## Links
+
+- **GitHub Repository**: [https://github.com/salvo-rs/salvo-skills](https://github.com/salvo-rs/salvo-skills)
+- **Agent Skills Standard**: [https://agent-skills.github.io/](https://agent-skills.github.io/)

--- a/docs/en/guide/topics/_meta.json
+++ b/docs/en/guide/topics/_meta.json
@@ -6,5 +6,6 @@
     "use-template-engine",
     "graceful-shutdown",
     "testing",
-    "deployment"
+    "deployment",
+    "ai-skills"
 ]

--- a/docs/en/guide/topics/ai-skills.mdx
+++ b/docs/en/guide/topics/ai-skills.mdx
@@ -1,0 +1,113 @@
+# AI Skills
+
+[Salvo Skills](https://github.com/salvo-rs/salvo-skills) is a collection of 27 specialized AI agent skills designed for the Salvo web framework. These skills follow the [Agent Skills](https://agent-skills.github.io/) open standard and help AI assistants understand and generate Salvo code more effectively.
+
+## What Are AI Skills?
+
+AI Skills are structured knowledge modules that provide AI coding assistants with deep, framework-specific expertise. When integrated into your development environment, they enable AI tools to:
+
+- Generate accurate, idiomatic Salvo code
+- Understand Salvo's architecture and conventions (e.g., `#[handler]` macro, Router, Depot)
+- Provide contextual guidance on topics like routing, middleware, authentication, WebSocket, and more
+
+## Available Skills (27 Total)
+
+| Category | Skills |
+| --- | --- |
+| **Core Framework** | `salvo-basic-app`, `salvo-routing`, `salvo-middleware`, `salvo-error-handling` |
+| **Data Handling** | `salvo-data-extraction`, `salvo-database`, `salvo-file-handling`, `salvo-static-files`, `salvo-caching` |
+| **Security** | `salvo-auth`, `salvo-session`, `salvo-csrf`, `salvo-cors`, `salvo-rate-limiter`, `salvo-tls-acme` |
+| **Real-time** | `salvo-realtime`, `salvo-websocket`, `salvo-sse` |
+| **Performance & Ops** | `salvo-compression`, `salvo-timeout`, `salvo-concurrency-limiter`, `salvo-graceful-shutdown`, `salvo-logging` |
+| **Advanced** | `salvo-openapi`, `salvo-proxy`, `salvo-flash`, `salvo-testing` |
+
+## Setup Guide
+
+### Claude Code
+
+Copy the skills into your project's `.claude/skills/` directory:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .claude/skills/
+```
+
+Skills load automatically when Claude Code works with your Salvo project.
+
+### GitHub Copilot (VS Code)
+
+1. Copy the skills into `.github/skills/`:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .github/skills/
+```
+
+2. Enable agent skills in VS Code settings:
+
+```json
+{
+  "chat.useAgentSkills": true
+}
+```
+
+Skills activate automatically when you discuss Salvo topics with Copilot.
+
+### Cursor
+
+Add skills as documentation context in Cursor:
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Create or edit the `.cursor/rules` file in your project root and add:
+
+```
+Read and follow the skill files in .cursor/skills/ directory for Salvo framework guidance.
+```
+
+3. Copy the skills:
+
+```bash
+cp -r salvo-skills/skills .cursor/skills/
+```
+
+Cursor will reference these skill files when generating Salvo-related code.
+
+### Windsurf
+
+Configure skills as knowledge context in Windsurf:
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Create or edit the `.windsurfrules` file in your project root and add:
+
+```
+Read and follow the skill files in .windsurf/skills/ directory for Salvo framework guidance.
+```
+
+3. Copy the skills:
+
+```bash
+cp -r salvo-skills/skills .windsurf/skills/
+```
+
+### Other AI Tools
+
+For any AI coding assistant that supports custom instructions or context files, you can:
+
+1. Clone the repository: `git clone https://github.com/salvo-rs/salvo-skills.git`
+2. Place the `skills/` folder in your project directory
+3. Configure your AI tool to reference these files as context
+
+## Links
+
+- **GitHub Repository**: [https://github.com/salvo-rs/salvo-skills](https://github.com/salvo-rs/salvo-skills)
+- **Agent Skills Standard**: [https://agent-skills.github.io/](https://agent-skills.github.io/)

--- a/docs/es/guide/topics/_meta.json
+++ b/docs/es/guide/topics/_meta.json
@@ -6,5 +6,6 @@
     "use-template-engine",
     "graceful-shutdown",
     "testing",
-    "deployment"
+    "deployment",
+    "ai-skills"
 ]

--- a/docs/es/guide/topics/ai-skills.mdx
+++ b/docs/es/guide/topics/ai-skills.mdx
@@ -1,0 +1,113 @@
+# AI Skills
+
+[Salvo Skills](https://github.com/salvo-rs/salvo-skills) es una colección de 27 habilidades especializadas de agentes de IA diseñadas para el framework web Salvo. Estas habilidades siguen el estándar abierto [Agent Skills](https://agent-skills.github.io/) y ayudan a los asistentes de programación con IA a comprender y generar código Salvo de manera más precisa y eficiente.
+
+## ¿Qué son los AI Skills?
+
+Los AI Skills son módulos de conocimiento estructurados que proporcionan a los asistentes de programación con IA un conocimiento profundo y específico del framework. Una vez integrados en tu entorno de desarrollo, las herramientas de IA pueden:
+
+- Generar código Salvo preciso e idiomático
+- Comprender la arquitectura y convenciones de Salvo (por ejemplo, macro `#[handler]`, Router, Depot)
+- Proporcionar orientación contextual sobre enrutamiento, middleware, autenticación, WebSocket y más
+
+## Habilidades disponibles (27 en total)
+
+| Categoría | Habilidades |
+| --- | --- |
+| **Framework central** | `salvo-basic-app`, `salvo-routing`, `salvo-middleware`, `salvo-error-handling` |
+| **Manejo de datos** | `salvo-data-extraction`, `salvo-database`, `salvo-file-handling`, `salvo-static-files`, `salvo-caching` |
+| **Seguridad** | `salvo-auth`, `salvo-session`, `salvo-csrf`, `salvo-cors`, `salvo-rate-limiter`, `salvo-tls-acme` |
+| **Tiempo real** | `salvo-realtime`, `salvo-websocket`, `salvo-sse` |
+| **Rendimiento y operaciones** | `salvo-compression`, `salvo-timeout`, `salvo-concurrency-limiter`, `salvo-graceful-shutdown`, `salvo-logging` |
+| **Avanzado** | `salvo-openapi`, `salvo-proxy`, `salvo-flash`, `salvo-testing` |
+
+## Guía de configuración
+
+### Claude Code
+
+Copia las habilidades en el directorio `.claude/skills/` de tu proyecto:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .claude/skills/
+```
+
+Claude Code carga automáticamente las habilidades al trabajar con tu proyecto Salvo.
+
+### GitHub Copilot (VS Code)
+
+1. Copia las habilidades en `.github/skills/`:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .github/skills/
+```
+
+2. Habilita las habilidades de agente en la configuración de VS Code:
+
+```json
+{
+  "chat.useAgentSkills": true
+}
+```
+
+Las habilidades se activan automáticamente cuando discutes temas de Salvo con Copilot.
+
+### Cursor
+
+Añade las habilidades como contexto de documentación en Cursor:
+
+1. Clona el repositorio:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Crea o edita el archivo `.cursor/rules` en la raíz del proyecto y añade:
+
+```
+Read and follow the skill files in .cursor/skills/ directory for Salvo framework guidance.
+```
+
+3. Copia los archivos de habilidades:
+
+```bash
+cp -r salvo-skills/skills .cursor/skills/
+```
+
+Cursor referenciará estos archivos al generar código relacionado con Salvo.
+
+### Windsurf
+
+Configura las habilidades como contexto de conocimiento en Windsurf:
+
+1. Clona el repositorio:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Crea o edita el archivo `.windsurfrules` en la raíz del proyecto y añade:
+
+```
+Read and follow the skill files in .windsurf/skills/ directory for Salvo framework guidance.
+```
+
+3. Copia los archivos de habilidades:
+
+```bash
+cp -r salvo-skills/skills .windsurf/skills/
+```
+
+### Otras herramientas de IA
+
+Para cualquier asistente de programación con IA que soporte instrucciones personalizadas o archivos de contexto:
+
+1. Clona el repositorio: `git clone https://github.com/salvo-rs/salvo-skills.git`
+2. Coloca la carpeta `skills/` en el directorio de tu proyecto
+3. Configura tu herramienta de IA para que referencie estos archivos como contexto
+
+## Enlaces
+
+- **Repositorio GitHub**: [https://github.com/salvo-rs/salvo-skills](https://github.com/salvo-rs/salvo-skills)
+- **Estándar Agent Skills**: [https://agent-skills.github.io/](https://agent-skills.github.io/)

--- a/docs/fr/guide/topics/_meta.json
+++ b/docs/fr/guide/topics/_meta.json
@@ -6,5 +6,6 @@
     "use-template-engine",
     "graceful-shutdown",
     "testing",
-    "deployment"
+    "deployment",
+    "ai-skills"
 ]

--- a/docs/fr/guide/topics/ai-skills.mdx
+++ b/docs/fr/guide/topics/ai-skills.mdx
@@ -1,0 +1,113 @@
+# AI Skills
+
+[Salvo Skills](https://github.com/salvo-rs/salvo-skills) est une collection de 27 compétences spécialisées d'agents IA conçues pour le framework web Salvo. Ces compétences suivent le standard ouvert [Agent Skills](https://agent-skills.github.io/) et aident les assistants de programmation IA à comprendre et générer du code Salvo de manière plus précise et efficace.
+
+## Que sont les AI Skills ?
+
+Les AI Skills sont des modules de connaissances structurés qui fournissent aux assistants de programmation IA une expertise approfondie et spécifique au framework. Une fois intégrés dans votre environnement de développement, les outils IA peuvent :
+
+- Générer du code Salvo précis et idiomatique
+- Comprendre l'architecture et les conventions de Salvo (par exemple, la macro `#[handler]`, Router, Depot)
+- Fournir des conseils contextuels sur le routage, les middlewares, l'authentification, WebSocket et plus encore
+
+## Compétences disponibles (27 au total)
+
+| Catégorie | Compétences |
+| --- | --- |
+| **Framework principal** | `salvo-basic-app`, `salvo-routing`, `salvo-middleware`, `salvo-error-handling` |
+| **Gestion des données** | `salvo-data-extraction`, `salvo-database`, `salvo-file-handling`, `salvo-static-files`, `salvo-caching` |
+| **Sécurité** | `salvo-auth`, `salvo-session`, `salvo-csrf`, `salvo-cors`, `salvo-rate-limiter`, `salvo-tls-acme` |
+| **Temps réel** | `salvo-realtime`, `salvo-websocket`, `salvo-sse` |
+| **Performance & opérations** | `salvo-compression`, `salvo-timeout`, `salvo-concurrency-limiter`, `salvo-graceful-shutdown`, `salvo-logging` |
+| **Avancé** | `salvo-openapi`, `salvo-proxy`, `salvo-flash`, `salvo-testing` |
+
+## Guide de configuration
+
+### Claude Code
+
+Copiez les compétences dans le répertoire `.claude/skills/` de votre projet :
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .claude/skills/
+```
+
+Claude Code charge automatiquement les compétences lorsqu'il travaille avec votre projet Salvo.
+
+### GitHub Copilot (VS Code)
+
+1. Copiez les compétences dans `.github/skills/` :
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .github/skills/
+```
+
+2. Activez les compétences d'agent dans les paramètres de VS Code :
+
+```json
+{
+  "chat.useAgentSkills": true
+}
+```
+
+Les compétences s'activent automatiquement lorsque vous discutez de sujets Salvo avec Copilot.
+
+### Cursor
+
+Ajoutez les compétences comme contexte de documentation dans Cursor :
+
+1. Clonez le dépôt :
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Créez ou éditez le fichier `.cursor/rules` à la racine du projet et ajoutez :
+
+```
+Read and follow the skill files in .cursor/skills/ directory for Salvo framework guidance.
+```
+
+3. Copiez les fichiers de compétences :
+
+```bash
+cp -r salvo-skills/skills .cursor/skills/
+```
+
+Cursor référencera ces fichiers lors de la génération de code lié à Salvo.
+
+### Windsurf
+
+Configurez les compétences comme contexte de connaissances dans Windsurf :
+
+1. Clonez le dépôt :
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Créez ou éditez le fichier `.windsurfrules` à la racine du projet et ajoutez :
+
+```
+Read and follow the skill files in .windsurf/skills/ directory for Salvo framework guidance.
+```
+
+3. Copiez les fichiers de compétences :
+
+```bash
+cp -r salvo-skills/skills .windsurf/skills/
+```
+
+### Autres outils IA
+
+Pour tout assistant de programmation IA supportant des instructions personnalisées ou des fichiers de contexte :
+
+1. Clonez le dépôt : `git clone https://github.com/salvo-rs/salvo-skills.git`
+2. Placez le dossier `skills/` dans le répertoire de votre projet
+3. Configurez votre outil IA pour référencer ces fichiers comme contexte
+
+## Liens
+
+- **Dépôt GitHub** : [https://github.com/salvo-rs/salvo-skills](https://github.com/salvo-rs/salvo-skills)
+- **Standard Agent Skills** : [https://agent-skills.github.io/](https://agent-skills.github.io/)

--- a/docs/it/guide/topics/_meta.json
+++ b/docs/it/guide/topics/_meta.json
@@ -6,5 +6,6 @@
     "use-template-engine",
     "graceful-shutdown",
     "testing",
-    "deployment"
+    "deployment",
+    "ai-skills"
 ]

--- a/docs/it/guide/topics/ai-skills.mdx
+++ b/docs/it/guide/topics/ai-skills.mdx
@@ -1,0 +1,113 @@
+# AI Skills
+
+[Salvo Skills](https://github.com/salvo-rs/salvo-skills) è una collezione di 27 skill specializzate per agenti IA progettate per il framework web Salvo. Queste skill seguono lo standard aperto [Agent Skills](https://agent-skills.github.io/) e aiutano gli assistenti di programmazione IA a comprendere e generare codice Salvo in modo più accurato ed efficiente.
+
+## Cosa sono gli AI Skills?
+
+Gli AI Skills sono moduli di conoscenza strutturati che forniscono agli assistenti di programmazione IA una competenza approfondita e specifica del framework. Una volta integrati nel tuo ambiente di sviluppo, gli strumenti IA possono:
+
+- Generare codice Salvo accurato e idiomatico
+- Comprendere l'architettura e le convenzioni di Salvo (ad esempio, macro `#[handler]`, Router, Depot)
+- Fornire indicazioni contestuali su routing, middleware, autenticazione, WebSocket e altro
+
+## Skill disponibili (27 in totale)
+
+| Categoria | Skill |
+| --- | --- |
+| **Framework principale** | `salvo-basic-app`, `salvo-routing`, `salvo-middleware`, `salvo-error-handling` |
+| **Gestione dati** | `salvo-data-extraction`, `salvo-database`, `salvo-file-handling`, `salvo-static-files`, `salvo-caching` |
+| **Sicurezza** | `salvo-auth`, `salvo-session`, `salvo-csrf`, `salvo-cors`, `salvo-rate-limiter`, `salvo-tls-acme` |
+| **Tempo reale** | `salvo-realtime`, `salvo-websocket`, `salvo-sse` |
+| **Prestazioni e operazioni** | `salvo-compression`, `salvo-timeout`, `salvo-concurrency-limiter`, `salvo-graceful-shutdown`, `salvo-logging` |
+| **Avanzato** | `salvo-openapi`, `salvo-proxy`, `salvo-flash`, `salvo-testing` |
+
+## Guida alla configurazione
+
+### Claude Code
+
+Copia le skill nella directory `.claude/skills/` del tuo progetto:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .claude/skills/
+```
+
+Claude Code carica automaticamente le skill quando lavora con il tuo progetto Salvo.
+
+### GitHub Copilot (VS Code)
+
+1. Copia le skill in `.github/skills/`:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .github/skills/
+```
+
+2. Abilita le skill agente nelle impostazioni di VS Code:
+
+```json
+{
+  "chat.useAgentSkills": true
+}
+```
+
+Le skill si attivano automaticamente quando discuti argomenti Salvo con Copilot.
+
+### Cursor
+
+Aggiungi le skill come contesto documentale in Cursor:
+
+1. Clona il repository:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Crea o modifica il file `.cursor/rules` nella radice del progetto e aggiungi:
+
+```
+Read and follow the skill files in .cursor/skills/ directory for Salvo framework guidance.
+```
+
+3. Copia i file delle skill:
+
+```bash
+cp -r salvo-skills/skills .cursor/skills/
+```
+
+Cursor farà riferimento a questi file durante la generazione di codice relativo a Salvo.
+
+### Windsurf
+
+Configura le skill come contesto di conoscenza in Windsurf:
+
+1. Clona il repository:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Crea o modifica il file `.windsurfrules` nella radice del progetto e aggiungi:
+
+```
+Read and follow the skill files in .windsurf/skills/ directory for Salvo framework guidance.
+```
+
+3. Copia i file delle skill:
+
+```bash
+cp -r salvo-skills/skills .windsurf/skills/
+```
+
+### Altri strumenti IA
+
+Per qualsiasi assistente di programmazione IA che supporti istruzioni personalizzate o file di contesto:
+
+1. Clona il repository: `git clone https://github.com/salvo-rs/salvo-skills.git`
+2. Posiziona la cartella `skills/` nella directory del tuo progetto
+3. Configura il tuo strumento IA per fare riferimento a questi file come contesto
+
+## Link
+
+- **Repository GitHub**: [https://github.com/salvo-rs/salvo-skills](https://github.com/salvo-rs/salvo-skills)
+- **Standard Agent Skills**: [https://agent-skills.github.io/](https://agent-skills.github.io/)

--- a/docs/ja/guide/topics/_meta.json
+++ b/docs/ja/guide/topics/_meta.json
@@ -6,5 +6,6 @@
     "use-template-engine",
     "graceful-shutdown",
     "testing",
-    "deployment"
+    "deployment",
+    "ai-skills"
 ]

--- a/docs/ja/guide/topics/ai-skills.mdx
+++ b/docs/ja/guide/topics/ai-skills.mdx
@@ -1,0 +1,113 @@
+# AI Skills
+
+[Salvo Skills](https://github.com/salvo-rs/salvo-skills) は、Salvo Web フレームワーク向けに設計された 27 個の専門 AI エージェントスキルのコレクションです。これらのスキルは [Agent Skills](https://agent-skills.github.io/) オープンスタンダードに準拠しており、AI コーディングアシスタントが Salvo コードをより正確かつ効率的に理解・生成できるようサポートします。
+
+## AI Skills とは?
+
+AI Skills は構造化されたナレッジモジュールで、AI コーディングアシスタントにフレームワーク固有の深い専門知識を提供します。開発環境に統合すると、AI ツールは以下のことが可能になります:
+
+- 正確で慣用的な Salvo コードの生成
+- Salvo のアーキテクチャと規約の理解 (例: `#[handler]` マクロ、Router、Depot)
+- ルーティング、ミドルウェア、認証、WebSocket などのトピックに関するコンテキストガイダンス
+
+## 利用可能なスキル (全 27 個)
+
+| カテゴリ | スキル |
+| --- | --- |
+| **コアフレームワーク** | `salvo-basic-app`, `salvo-routing`, `salvo-middleware`, `salvo-error-handling` |
+| **データ処理** | `salvo-data-extraction`, `salvo-database`, `salvo-file-handling`, `salvo-static-files`, `salvo-caching` |
+| **セキュリティ** | `salvo-auth`, `salvo-session`, `salvo-csrf`, `salvo-cors`, `salvo-rate-limiter`, `salvo-tls-acme` |
+| **リアルタイム** | `salvo-realtime`, `salvo-websocket`, `salvo-sse` |
+| **パフォーマンス & 運用** | `salvo-compression`, `salvo-timeout`, `salvo-concurrency-limiter`, `salvo-graceful-shutdown`, `salvo-logging` |
+| **高度な機能** | `salvo-openapi`, `salvo-proxy`, `salvo-flash`, `salvo-testing` |
+
+## セットアップガイド
+
+### Claude Code
+
+スキルをプロジェクトの `.claude/skills/` ディレクトリにコピーします:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .claude/skills/
+```
+
+Claude Code は Salvo プロジェクトで作業する際にスキルを自動的にロードします。
+
+### GitHub Copilot (VS Code)
+
+1. スキルを `.github/skills/` にコピーします:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .github/skills/
+```
+
+2. VS Code の設定でエージェントスキルを有効にします:
+
+```json
+{
+  "chat.useAgentSkills": true
+}
+```
+
+Copilot で Salvo 関連のトピックについて議論すると、スキルが自動的に有効になります。
+
+### Cursor
+
+Cursor でスキルをドキュメントコンテキストとして追加します:
+
+1. リポジトリをクローンします:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. プロジェクトルートの `.cursor/rules` ファイルを作成または編集し、以下を追加します:
+
+```
+Read and follow the skill files in .cursor/skills/ directory for Salvo framework guidance.
+```
+
+3. スキルファイルをコピーします:
+
+```bash
+cp -r salvo-skills/skills .cursor/skills/
+```
+
+Cursor は Salvo 関連のコードを生成する際にこれらのスキルファイルを参照します。
+
+### Windsurf
+
+Windsurf でスキルをナレッジコンテキストとして設定します:
+
+1. リポジトリをクローンします:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. プロジェクトルートの `.windsurfrules` ファイルを作成または編集し、以下を追加します:
+
+```
+Read and follow the skill files in .windsurf/skills/ directory for Salvo framework guidance.
+```
+
+3. スキルファイルをコピーします:
+
+```bash
+cp -r salvo-skills/skills .windsurf/skills/
+```
+
+### その他の AI ツール
+
+カスタム指示やコンテキストファイルをサポートする AI コーディングアシスタントであれば、以下の手順で利用できます:
+
+1. リポジトリをクローン: `git clone https://github.com/salvo-rs/salvo-skills.git`
+2. `skills/` フォルダをプロジェクトディレクトリに配置
+3. AI ツールでこれらのファイルをコンテキストとして参照するよう設定
+
+## 関連リンク
+
+- **GitHub リポジトリ**: [https://github.com/salvo-rs/salvo-skills](https://github.com/salvo-rs/salvo-skills)
+- **Agent Skills 標準**: [https://agent-skills.github.io/](https://agent-skills.github.io/)

--- a/docs/pt/guide/topics/_meta.json
+++ b/docs/pt/guide/topics/_meta.json
@@ -6,5 +6,6 @@
     "use-template-engine",
     "graceful-shutdown",
     "testing",
-    "deployment"
+    "deployment",
+    "ai-skills"
 ]

--- a/docs/pt/guide/topics/ai-skills.mdx
+++ b/docs/pt/guide/topics/ai-skills.mdx
@@ -1,0 +1,113 @@
+# AI Skills
+
+[Salvo Skills](https://github.com/salvo-rs/salvo-skills) é uma coleção de 27 habilidades especializadas de agentes de IA projetadas para o framework web Salvo. Essas habilidades seguem o padrão aberto [Agent Skills](https://agent-skills.github.io/) e ajudam assistentes de programação com IA a compreender e gerar código Salvo de forma mais precisa e eficiente.
+
+## O que são AI Skills?
+
+AI Skills são módulos de conhecimento estruturados que fornecem aos assistentes de programação com IA um conhecimento profundo e específico do framework. Após a integração no seu ambiente de desenvolvimento, as ferramentas de IA podem:
+
+- Gerar código Salvo preciso e idiomático
+- Compreender a arquitetura e convenções do Salvo (por exemplo, macro `#[handler]`, Router, Depot)
+- Fornecer orientação contextual sobre roteamento, middleware, autenticação, WebSocket e mais
+
+## Habilidades disponíveis (27 no total)
+
+| Categoria | Habilidades |
+| --- | --- |
+| **Framework principal** | `salvo-basic-app`, `salvo-routing`, `salvo-middleware`, `salvo-error-handling` |
+| **Manipulação de dados** | `salvo-data-extraction`, `salvo-database`, `salvo-file-handling`, `salvo-static-files`, `salvo-caching` |
+| **Segurança** | `salvo-auth`, `salvo-session`, `salvo-csrf`, `salvo-cors`, `salvo-rate-limiter`, `salvo-tls-acme` |
+| **Tempo real** | `salvo-realtime`, `salvo-websocket`, `salvo-sse` |
+| **Desempenho e operações** | `salvo-compression`, `salvo-timeout`, `salvo-concurrency-limiter`, `salvo-graceful-shutdown`, `salvo-logging` |
+| **Avançado** | `salvo-openapi`, `salvo-proxy`, `salvo-flash`, `salvo-testing` |
+
+## Guia de configuração
+
+### Claude Code
+
+Copie as habilidades para o diretório `.claude/skills/` do seu projeto:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .claude/skills/
+```
+
+O Claude Code carrega automaticamente as habilidades ao trabalhar com seu projeto Salvo.
+
+### GitHub Copilot (VS Code)
+
+1. Copie as habilidades para `.github/skills/`:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .github/skills/
+```
+
+2. Ative as habilidades de agente nas configurações do VS Code:
+
+```json
+{
+  "chat.useAgentSkills": true
+}
+```
+
+As habilidades são ativadas automaticamente quando você discute tópicos do Salvo com o Copilot.
+
+### Cursor
+
+Adicione as habilidades como contexto de documentação no Cursor:
+
+1. Clone o repositório:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Crie ou edite o arquivo `.cursor/rules` na raiz do projeto e adicione:
+
+```
+Read and follow the skill files in .cursor/skills/ directory for Salvo framework guidance.
+```
+
+3. Copie os arquivos de habilidades:
+
+```bash
+cp -r salvo-skills/skills .cursor/skills/
+```
+
+O Cursor referenciará esses arquivos ao gerar código relacionado ao Salvo.
+
+### Windsurf
+
+Configure as habilidades como contexto de conhecimento no Windsurf:
+
+1. Clone o repositório:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. Crie ou edite o arquivo `.windsurfrules` na raiz do projeto e adicione:
+
+```
+Read and follow the skill files in .windsurf/skills/ directory for Salvo framework guidance.
+```
+
+3. Copie os arquivos de habilidades:
+
+```bash
+cp -r salvo-skills/skills .windsurf/skills/
+```
+
+### Outras ferramentas de IA
+
+Para qualquer assistente de programação com IA que suporte instruções personalizadas ou arquivos de contexto:
+
+1. Clone o repositório: `git clone https://github.com/salvo-rs/salvo-skills.git`
+2. Coloque a pasta `skills/` no diretório do seu projeto
+3. Configure sua ferramenta de IA para referenciar esses arquivos como contexto
+
+## Links
+
+- **Repositório GitHub**: [https://github.com/salvo-rs/salvo-skills](https://github.com/salvo-rs/salvo-skills)
+- **Padrão Agent Skills**: [https://agent-skills.github.io/](https://agent-skills.github.io/)

--- a/docs/zh-hans/guide/topics/_meta.json
+++ b/docs/zh-hans/guide/topics/_meta.json
@@ -6,5 +6,6 @@
     "use-template-engine",
     "graceful-shutdown",
     "testing",
-    "deployment"
+    "deployment",
+    "ai-skills"
 ]

--- a/docs/zh-hans/guide/topics/ai-skills.mdx
+++ b/docs/zh-hans/guide/topics/ai-skills.mdx
@@ -1,0 +1,113 @@
+# AI Skills
+
+[Salvo Skills](https://github.com/salvo-rs/salvo-skills) 是一套为 Salvo Web 框架设计的 27 个专业 AI 代理技能集合。这些技能遵循 [Agent Skills](https://agent-skills.github.io/) 开放标准, 帮助 AI 编程助手更准确高效地理解和生成 Salvo 代码。
+
+## 什么是 AI Skills?
+
+AI Skills 是结构化的知识模块, 为 AI 编程助手提供深度的框架专业知识。集成到开发环境后, AI 工具可以:
+
+- 生成准确、地道的 Salvo 代码
+- 理解 Salvo 的架构和约定 (如 `#[handler]` 宏、Router、Depot 等)
+- 提供路由、中间件、认证、WebSocket 等主题的上下文指导
+
+## 可用技能 (共 27 个)
+
+| 类别 | 技能 |
+| --- | --- |
+| **核心框架** | `salvo-basic-app`, `salvo-routing`, `salvo-middleware`, `salvo-error-handling` |
+| **数据处理** | `salvo-data-extraction`, `salvo-database`, `salvo-file-handling`, `salvo-static-files`, `salvo-caching` |
+| **安全** | `salvo-auth`, `salvo-session`, `salvo-csrf`, `salvo-cors`, `salvo-rate-limiter`, `salvo-tls-acme` |
+| **实时通信** | `salvo-realtime`, `salvo-websocket`, `salvo-sse` |
+| **性能与运维** | `salvo-compression`, `salvo-timeout`, `salvo-concurrency-limiter`, `salvo-graceful-shutdown`, `salvo-logging` |
+| **高级功能** | `salvo-openapi`, `salvo-proxy`, `salvo-flash`, `salvo-testing` |
+
+## 配置指南
+
+### Claude Code
+
+将技能复制到项目的 `.claude/skills/` 目录:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .claude/skills/
+```
+
+Claude Code 在处理你的 Salvo 项目时会自动加载这些技能。
+
+### GitHub Copilot (VS Code)
+
+1. 将技能复制到 `.github/skills/`:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .github/skills/
+```
+
+2. 在 VS Code 设置中启用代理技能:
+
+```json
+{
+  "chat.useAgentSkills": true
+}
+```
+
+当你与 Copilot 讨论 Salvo 相关话题时, 技能会自动激活。
+
+### Cursor
+
+在 Cursor 中将技能添加为文档上下文:
+
+1. 克隆仓库:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. 在项目根目录创建或编辑 `.cursor/rules` 文件, 添加:
+
+```
+Read and follow the skill files in .cursor/skills/ directory for Salvo framework guidance.
+```
+
+3. 复制技能文件:
+
+```bash
+cp -r salvo-skills/skills .cursor/skills/
+```
+
+Cursor 在生成 Salvo 相关代码时会参考这些技能文件。
+
+### Windsurf
+
+在 Windsurf 中配置技能作为知识上下文:
+
+1. 克隆仓库:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. 在项目根目录创建或编辑 `.windsurfrules` 文件, 添加:
+
+```
+Read and follow the skill files in .windsurf/skills/ directory for Salvo framework guidance.
+```
+
+3. 复制技能文件:
+
+```bash
+cp -r salvo-skills/skills .windsurf/skills/
+```
+
+### 其他 AI 工具
+
+对于任何支持自定义指令或上下文文件的 AI 编程助手, 你可以:
+
+1. 克隆仓库: `git clone https://github.com/salvo-rs/salvo-skills.git`
+2. 将 `skills/` 文件夹放置到你的项目目录中
+3. 配置你的 AI 工具引用这些文件作为上下文
+
+## 相关链接
+
+- **GitHub 仓库**: [https://github.com/salvo-rs/salvo-skills](https://github.com/salvo-rs/salvo-skills)
+- **Agent Skills 标准**: [https://agent-skills.github.io/](https://agent-skills.github.io/)

--- a/docs/zh-hant/guide/topics/_meta.json
+++ b/docs/zh-hant/guide/topics/_meta.json
@@ -6,5 +6,6 @@
     "use-template-engine",
     "graceful-shutdown",
     "testing",
-    "deployment"
+    "deployment",
+    "ai-skills"
 ]

--- a/docs/zh-hant/guide/topics/ai-skills.mdx
+++ b/docs/zh-hant/guide/topics/ai-skills.mdx
@@ -1,0 +1,113 @@
+# AI Skills
+
+[Salvo Skills](https://github.com/salvo-rs/salvo-skills) 是一套為 Salvo Web 框架設計的 27 個專業 AI 代理技能集合。這些技能遵循 [Agent Skills](https://agent-skills.github.io/) 開放標準, 幫助 AI 程式設計助手更準確高效地理解和生成 Salvo 程式碼。
+
+## 什麼是 AI Skills?
+
+AI Skills 是結構化的知識模組, 為 AI 程式設計助手提供深度的框架專業知識。整合到開發環境後, AI 工具可以:
+
+- 生成準確、道地的 Salvo 程式碼
+- 理解 Salvo 的架構和約定 (如 `#[handler]` 巨集、Router、Depot 等)
+- 提供路由、中介軟體、認證、WebSocket 等主題的上下文指導
+
+## 可用技能 (共 27 個)
+
+| 類別 | 技能 |
+| --- | --- |
+| **核心框架** | `salvo-basic-app`, `salvo-routing`, `salvo-middleware`, `salvo-error-handling` |
+| **資料處理** | `salvo-data-extraction`, `salvo-database`, `salvo-file-handling`, `salvo-static-files`, `salvo-caching` |
+| **安全** | `salvo-auth`, `salvo-session`, `salvo-csrf`, `salvo-cors`, `salvo-rate-limiter`, `salvo-tls-acme` |
+| **即時通訊** | `salvo-realtime`, `salvo-websocket`, `salvo-sse` |
+| **效能與維運** | `salvo-compression`, `salvo-timeout`, `salvo-concurrency-limiter`, `salvo-graceful-shutdown`, `salvo-logging` |
+| **進階功能** | `salvo-openapi`, `salvo-proxy`, `salvo-flash`, `salvo-testing` |
+
+## 設定指南
+
+### Claude Code
+
+將技能複製到專案的 `.claude/skills/` 目錄:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .claude/skills/
+```
+
+Claude Code 在處理你的 Salvo 專案時會自動載入這些技能。
+
+### GitHub Copilot (VS Code)
+
+1. 將技能複製到 `.github/skills/`:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+cp -r salvo-skills/skills .github/skills/
+```
+
+2. 在 VS Code 設定中啟用代理技能:
+
+```json
+{
+  "chat.useAgentSkills": true
+}
+```
+
+當你與 Copilot 討論 Salvo 相關話題時, 技能會自動啟動。
+
+### Cursor
+
+在 Cursor 中將技能新增為文件上下文:
+
+1. 複製儲存庫:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. 在專案根目錄建立或編輯 `.cursor/rules` 檔案, 新增:
+
+```
+Read and follow the skill files in .cursor/skills/ directory for Salvo framework guidance.
+```
+
+3. 複製技能檔案:
+
+```bash
+cp -r salvo-skills/skills .cursor/skills/
+```
+
+Cursor 在生成 Salvo 相關程式碼時會參考這些技能檔案。
+
+### Windsurf
+
+在 Windsurf 中設定技能作為知識上下文:
+
+1. 複製儲存庫:
+
+```bash
+git clone https://github.com/salvo-rs/salvo-skills.git
+```
+
+2. 在專案根目錄建立或編輯 `.windsurfrules` 檔案, 新增:
+
+```
+Read and follow the skill files in .windsurf/skills/ directory for Salvo framework guidance.
+```
+
+3. 複製技能檔案:
+
+```bash
+cp -r salvo-skills/skills .windsurf/skills/
+```
+
+### 其他 AI 工具
+
+對於任何支援自訂指令或上下文檔案的 AI 程式設計助手, 你可以:
+
+1. 複製儲存庫: `git clone https://github.com/salvo-rs/salvo-skills.git`
+2. 將 `skills/` 資料夾放置到你的專案目錄中
+3. 設定你的 AI 工具參考這些檔案作為上下文
+
+## 相關連結
+
+- **GitHub 儲存庫**: [https://github.com/salvo-rs/salvo-skills](https://github.com/salvo-rs/salvo-skills)
+- **Agent Skills 標準**: [https://agent-skills.github.io/](https://agent-skills.github.io/)


### PR DESCRIPTION
## Summary
- Add new **AI Skills** documentation page explaining [salvo-skills](https://github.com/salvo-rs/salvo-skills) — a collection of 27 specialized AI agent skills for the Salvo web framework
- Include setup guides for **Claude Code**, **GitHub Copilot (VS Code)**, **Cursor**, **Windsurf**, and other AI tools
- Add the page across all 9 supported languages (en, zh-hans, zh-hant, ja, de, es, fr, it, pt)

## Test plan
- [ ] Verify the new page renders correctly in English
- [ ] Verify navigation sidebar shows "AI Skills" under Topics section
- [ ] Verify all 9 language versions are accessible
- [ ] Verify all external links (GitHub repo, Agent Skills standard) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)