### PR TITLE
docs(request): #[serde(flatten)] unsupported on Extractible fields

### DIFF
--- a/docs/en/guide/concepts/request.md
+++ b/docs/en/guide/concepts/request.md
@@ -295,7 +295,14 @@ For a concrete example, see: [extract-nested](https://github.com/salvo-rs/salvo/
 
 ### `#[salvo(extract(flatten))]` VS `#[serde(flatten)]`
 
-If in the above example Nested<'a> does not have fields with the same names as the parent, you can use `#[serde(flatten)]`. Otherwise, you need to use `#[salvo(extract(flatten))]`.
+To flatten an extractible sub-struct, use `#[salvo(extract(flatten))]`. Its fields
+are extracted from the same request sources as the parent, so they may even share
+field names with the parent.
+
+`#[serde(flatten)]` is **not supported** on `#[derive(Extractible)]` fields: it
+drives serde's own flattening, which conflicts with Salvo's extraction and used to
+surface as confusing "missing field" errors at request time. Salvo now rejects it
+at compile time with a message pointing you to `#[salvo(extract(flatten))]`.
 
 ### `#[salvo(extract(source(parse)))]`
 

--- a/docs/zh-hans/guide/concepts/request.md
+++ b/docs/zh-hans/guide/concepts/request.md
@@ -298,7 +298,7 @@ struct Nested<'a> {
 
 要展平一个可提取的子结构体，请使用 `#[salvo(extract(flatten))]`。它的字段会从与父结构体相同的请求来源中提取，因此甚至可以与父结构体有同名字段。
 
-`#[salvo(extract(flatten))]` 字段上**不支持** `#[serde(flatten)]`：后者会触发 serde 自己的展平逻辑，与 Salvo 的提取机制冲突，过去会在请求时表现为令人困惑的 “missing field” 错误。现在 Salvo 会在**编译期**直接报错，并提示改用 `#[salvo(extract(flatten))]`。
+`#[derive(Extractible)]` 结构体的字段上**不支持** `#[serde(flatten)]`：后者会触发 serde 自己的展平逻辑，与 Salvo 的提取机制冲突，过去会在请求时表现为令人困惑的 “missing field” 错误。现在 Salvo 会在**编译期**直接报错，并提示改用 `#[salvo(extract(flatten))]`。
 
 ### `#[salvo(extract(source(parse)))]`
 

--- a/docs/zh-hans/guide/concepts/request.md
+++ b/docs/zh-hans/guide/concepts/request.md
@@ -296,7 +296,9 @@ struct Nested<'a> {
 
 ### `#[salvo(extract(flatten))]` VS `#[serde(flatten)]`
 
-如果在上面例子中 Nested<'a> 没有与父级相同的字段，可以使用 `#[serde(flatten)]`, 否则需要使用 `#[salvo(extract(flatten))]`.
+要展平一个可提取的子结构体，请使用 `#[salvo(extract(flatten))]`。它的字段会从与父结构体相同的请求来源中提取，因此甚至可以与父结构体有同名字段。
+
+`#[salvo(extract(flatten))]` 字段上**不支持** `#[serde(flatten)]`：后者会触发 serde 自己的展平逻辑，与 Salvo 的提取机制冲突，过去会在请求时表现为令人困惑的 “missing field” 错误。现在 Salvo 会在**编译期**直接报错，并提示改用 `#[salvo(extract(flatten))]`。
 
 ### `#[salvo(extract(source(parse)))]`
 

--- a/docs/zh-hant/guide/concepts/request.md
+++ b/docs/zh-hant/guide/concepts/request.md
@@ -295,7 +295,9 @@ struct Nested<'a> {
 
 ### `#[salvo(extract(flatten))]` VS `#[serde(flatten)]`
 
-如果在上面的例子中，Nested<'a> 沒有與父層相同的欄位，可以使用 `#[serde(flatten)]`，否則需要使用 `#[salvo(extract(flatten))]`。
+要展平一個可提取的子結構體，請使用 `#[salvo(extract(flatten))]`。它的欄位會從與父結構體相同的請求來源中提取，因此甚至可以與父結構體有同名欄位。
+
+`#[salvo(extract(flatten))]` 欄位上**不支援** `#[serde(flatten)]`：後者會觸發 serde 自己的展平邏輯，與 Salvo 的提取機制衝突，過去會在請求時表現為令人困惑的 “missing field” 錯誤。現在 Salvo 會在**編譯期**直接報錯，並提示改用 `#[salvo(extract(flatten))]`。
 
 ### `#[salvo(extract(source(parse)))]`
 

--- a/docs/zh-hant/guide/concepts/request.md
+++ b/docs/zh-hant/guide/concepts/request.md
@@ -297,7 +297,7 @@ struct Nested<'a> {
 
 要展平一個可提取的子結構體，請使用 `#[salvo(extract(flatten))]`。它的欄位會從與父結構體相同的請求來源中提取，因此甚至可以與父結構體有同名欄位。
 
-`#[salvo(extract(flatten))]` 欄位上**不支援** `#[serde(flatten)]`：後者會觸發 serde 自己的展平邏輯，與 Salvo 的提取機制衝突，過去會在請求時表現為令人困惑的 “missing field” 錯誤。現在 Salvo 會在**編譯期**直接報錯，並提示改用 `#[salvo(extract(flatten))]`。
+`#[derive(Extractible)]` 結構體的欄位上**不支援** `#[serde(flatten)]`：後者會觸發 serde 自己的展平邏輯，與 Salvo 的提取機制衝突，過去會在請求時表現為令人困惑的 “missing field” 錯誤。現在 Salvo 會在**編譯期**直接報錯，並提示改用 `#[salvo(extract(flatten))]`。
 
 ### `#[salvo(extract(source(parse)))]`
 

--- a/docs/zh-hant/guide/concepts/request.md
+++ b/docs/zh-hant/guide/concepts/request.md
@@ -364,4 +364,4 @@ async fn test_de_request_with_form_json_str() {
 | **特殊功能** | `cookies()/cookie()` | Cookie 操作（需 cookie feature） |
 | | `extensions()/extensions_mut()` | 擴充資料儲存 |
 | | `set_secure_max_size()` | 設定安全大小限制 |
-{/* Auto generated, origin file hash:6b654f79df08ba1dc5cc1c070780def0 */}
+{/* Auto generated, origin file hash:cb75a2ba6a8df09df0e05203e5c8d215 */}


### PR DESCRIPTION
Follow-up to salvo-rs/salvo#1611, which makes `#[serde(flatten)]` on `#[derive(Extractible)]` fields a compile error (it conflicts with Salvo's own flattening and used to surface as runtime `missing field` errors).

Updates the "`#[salvo(extract(flatten))]` VS `#[serde(flatten)]`" section in `guide/concepts/request.md` for **en / zh-hans / zh-hant**: flatten an extractible sub-struct with `#[salvo(extract(flatten))]` (fields extracted from the same sources as the parent, may share names); `#[serde(flatten)]` is not supported and now rejected at compile time.

Note: other locales (de/es/fr/it/ja/pt) still carry the old wording and can be updated by their translators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)